### PR TITLE
new subtask: nyc_intersections crashcount

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ Install Python requirements:
 pip install -r requirements.txt
 ```
 
+### Pre-Setup on Windows
+
+If you run Windows, you will need to install Python; also, I recommend running under "git bash" as it provides some Unix-like tools and behaviors.
+
+* Install Python for Windows. If you run ArcMap then you probably already have one under *C:\Python27*
+* Install Git for Windows. Open a "Git bash here" for a better command line experience.
+* Set some aliases in your `~/.bashrc` file, then `. ~/.bashrc`
+```
+PATH="$PATH:/c/Python27/ArcGIS10.5/:/c/Python27/ArcGIS10.5/Scripts/"
+alias python='winpty /c/Python27/ArcGIS10.5/python.exe'
+alias pip='/c/Python27/ArcGIS10.5/Scripts/pip.exe'
+```
+* Install foreman for running tasks: `npm install -g foreman` Then remember that command-lines startnig with "foreman" should start with "nf" instead.
+
+
 ## Running Locally
 
 To execute script locally using Python 2.7 and Foreman by doing:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ PATH="$PATH:/c/Python27/ArcGIS10.5/:/c/Python27/ArcGIS10.5/Scripts/"
 alias python='winpty /c/Python27/ArcGIS10.5/python.exe'
 alias pip='/c/Python27/ArcGIS10.5/Scripts/pip.exe'
 ```
-* Install foreman for running tasks: `npm install -g foreman` Then remember that command-lines startnig with "foreman" should start with "nf" instead.
+* Install foreman for running tasks: `npm install -g foreman` Then remember that command-lines starting with "foreman" should start with "nf" instead.
 
 
 ## Running Locally

--- a/main.py
+++ b/main.py
@@ -4,6 +4,8 @@
 import requests
 import urllib
 from datetime import datetime
+from datetime import date
+from dateutil.relativedelta import relativedelta
 import json
 import logging
 import sys
@@ -25,71 +27,61 @@ logging.basicConfig(
 logger = logging.getLogger()
 
 
-def get_max_date_from_carto():
+def get_soda_data():
     """
-    Makes a GET request to the CARTO SQL API for the most recent date
-    from the crash data table. Returns the date as a datetime date object
+    Make a GET request to the Socrata SODA API for collision data within the last month.
+    Limit is purposefully set high as it defaults to 1000, and we routinely see 500 crashes in a single day.
+    Make a call to CARTO to get the list of all socrata_id IDs in this same time period.
     """
-    query='SELECT max(date_val) as latest_date FROM %s' % CARTO_CRASHES_TABLE
-    logger.info('Getting latest date from table %s...' % CARTO_CRASHES_TABLE)
+    amonthago = (date.today() - relativedelta(months=1))
 
+    logger.info('Getting data from Socrata SODA API as of {0}'.format(amonthago))
     try:
-        r = requests.get(CARTO_SQL_API_BASEURL, params={'q': query})
+        crashdata = requests.get(
+            SODA_API_COLLISIONS_BASEURL,
+            params={
+                '$where': "date >= '%s'" % amonthago.strftime('%Y-%m-%d'),
+                '$order': 'date DESC',
+                '$limit': '50000'
+            },
+            verify=False  # requests hates the SSL certificate due to hostname mismatch, but it IS valid
+        ).json()
     except requests.exceptions.RequestException as e:
         logger.error(e.message)
         sys.exit(1)
 
-    data = r.json()
-
-    if ('rows' in data) and len(data['rows']):
-        datestring = data['rows'][0]['latest_date']
-        global LATEST_DATE
-        LATEST_DATE = datestring
-        latest_date = datetime.strptime(datestring, '%Y-%m-%dT%H:%M:%SZ')
-        logger.info('Latest date from table %s is %s' % (CARTO_CRASHES_TABLE, latest_date))
-    else:
-        logger.error('No rows in response from %s' % CARTO_CRASHES_TABLE, json.dumps(data))
+    if isinstance(crashdata, list) and len(crashdata):  # this is good, the expected condition
+        logger.info('Got {0} SODA entries OK'.format(len(crashdata)))
+        # print(json.dumps(crashdata))
+    elif isinstance(crashdata, dict) and crashdata['error']:  # error in SODA API call
+        logger.error(crashdata['message'])
         sys.exit(1)
-
-    return latest_date
-
-
-def get_soda_data(dateobj):
-    """
-    Makes a GET request to the Socrata SODA API for collision data
-    using a where filter, order (by), and limit in the request.
-    Limit is purposefully set high in case the Socrata data hasn't
-    been updated in a few months.
-    @param {dateobj} datetime date object of the last date in the crashes table
-    """
-    datestring = dateobj.strftime('%Y-%m-%d')
-    payload = {
-        '$where': "date >= '%s'" % datestring,
-        '$order': 'date DESC',
-        '$limit': '60000'
-    }
-
-    logger.info('Getting latest collision data from Socrata SODA API...')
-
-    try:
-        r = requests.get(SODA_API_COLLISIONS_BASEURL, params=payload, verify=False)  # requests hates the SSL certificate due to hostname mismatch, but it IS valid
-    except requests.exceptions.RequestException as e:
-        logger.error(e.message)
-        sys.exit(1)
-
-    data = r.json()
-
-    if isinstance(data, list) and len(data):
-        # there's data!
-        # print(json.dumps(data))
-        format_soda_response(data)
-    elif isinstance(data, dict) and data['error']:
-        # error in SODA API call
-        logger.error(data['message'])
-        sys.exit(1)
-    else:
+    else:  # no data?
         logger.info('No data returned from Socrata, exiting.')
         sys.exit()
+
+    logger.info('Getting socrata_id list from CARTO as of {0}'.format(amonthago))
+    try:
+        alreadydata = requests.get(
+            CARTO_SQL_API_BASEURL,
+            params={
+                'q': "SELECT socrata_id FROM {0} WHERE date_val >= '{1}'".format(CARTO_CRASHES_TABLE, amonthago.strftime('%Y-%m-%dT00:00:00Z')),
+            }
+        ).json()
+    except requests.exceptions.RequestException as e:
+        logger.error(e.message)
+        sys.exit(1)
+    if not 'rows' in alreadydata or not len(alreadydata['rows']):
+        logger.error('No socrata_id rows: {0}'.format(json.dumps(alreadydata)))
+        sys.exit(1)
+
+    socrata_already = [ r['socrata_id'] for r in alreadydata['rows'] ]
+    # print(socrata_already)
+    logger.info('Got {0} socrata_id entries for existing CARTO records'.format(len(socrata_already)))
+
+    # all done! hand off for real processing
+    format_soda_response(crashdata, socrata_already)
+
 
 
 def format_string_for_postgres_array(values, field_name):
@@ -139,12 +131,12 @@ def format_string_for_insert_val():
     return '(' + ','.join(val_string_tmp) + ')'
 
 
-def format_soda_response(data):
+def format_soda_response(datarows, already_ids):
     """
     Transforms the JSON SODA response into rows for the SQL insert query
     @param {list} data
     """
-    logger.info('Processing {} rows from SODA API.'.format(len(data)))
+    # logger.info('Processing {} rows from SODA API.'.format(len(datarows)))
 
     # array to store insert value strings
     vals = []
@@ -153,7 +145,12 @@ def format_soda_response(data):
     insert_val_template_string = format_string_for_insert_val()
 
     # iterate over data array and format each dictionary's values into strings for the INSERT SQL query
-    for row in data:
+    for row in datarows:
+        # this is already present at CARTO, don't insert a duplicate!
+        # see also create_sql_insert() which has a check as well, but it's A LOT more efficient to bail here
+        if int(row['unique_key']) in already_ids:
+            continue
+
         datestring = "%sT%s" % (row['date'].split('T')[0], row['time'])
         date_time = datetime.strptime(datestring, '%Y-%m-%dT%H:%M')
 
@@ -246,6 +243,11 @@ def format_soda_response(data):
             str(row['unique_key'])
         ))
 
+        # print([ str(row['unique_key']), date_time.strftime('%Y-%m-%dT%H:%M:%SZ'),lng, lat ])
+
+    logger.info('Found {0} new rows to insert into CARTO'.format(len(vals)))
+
+    # ready, go ahead and submit them
     update_carto_table(vals)
 
 
@@ -488,7 +490,7 @@ def update_carto_table(vals):
 
 def main():
     # get the most recent data from New York's data endpoint, and load it
-    get_soda_data(get_max_date_from_carto())
+    get_soda_data()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This builds on PR 3 (some minor fixes) so merging PR 3 may resolve a few diffs and make this one easier to read.

**DO NOT MERGE THIS until some decisions are made re https://github.com/GreenInfo-Network/nyc-crash-mapper-chart-view/issues/73** as our direction may change as we discuss.

* adds new utility function `get_date_monthsago_from_carto()` to get a PostgreSQL date string from X months ago
* adds new subtask function `update_intersections_crashcount()` to update the new **nyc_intersections** table *crashcount* field This is per  https://github.com/GreenInfo-Network/nyc-crash-mapper-chart-view/issues/73 in which we will want to display intersections and compare them